### PR TITLE
Add HelloWorlod endpoint

### DIFF
--- a/e2e/scenario/api.yaml
+++ b/e2e/scenario/api.yaml
@@ -18,4 +18,11 @@ steps:
     url: "http://localhost:8081/shells/{{vars.aas_id}}"
   expect:
     code: 404
-
+- title: GET helloworld
+  protocol: http
+  request:
+    method: GET
+    url: "http://localhost:8081/helloworld"
+  expect:
+    code: 200
+    body: "HelloWorlod"

--- a/gen/source/basyx-aas.yaml
+++ b/gen/source/basyx-aas.yaml
@@ -811,6 +811,19 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Result'
+  /helloworld:
+    get:
+      tags:
+      - HelloWorld
+      summary: Returns a greeting message
+      operationId: GetHelloWorlod
+      responses:
+        "200":
+          description: Returns the greeting message
+          content:
+            text/plain:
+              schema:
+                type: string
 components:
   schemas:
     AssetAdministrationShell:

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -300,6 +300,11 @@ func (s Server) ShellRepoPutSubmodelElementValueByIdShort(ctx echo.Context, aasI
 	return ctx.JSON(http.StatusNotImplemented, nil)
 }
 
+// New handler function to return "HelloWorlod"
+func (s Server) GetHelloWorlod(ctx echo.Context) error {
+	return ctx.String(http.StatusOK, "HelloWorlod")
+}
+
 func NewServer(ctx context.Context) (*echo.Echo, error) {
 	instance := echo.New()
 	aCli, err := aas.NewAas()
@@ -311,5 +316,9 @@ func NewServer(ctx context.Context) (*echo.Echo, error) {
 
 	// 自動生成されたハンドラ登録関数にServerInterfaceを満たすserverを渡す
 	basyxAas.RegisterHandlers(instance, server)
+
+	// Register the new handler function
+	instance.GET("/helloworld", server.GetHelloWorlod)
+
 	return instance, nil
 }

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -2,7 +2,11 @@ package server
 
 import (
 	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"testing"
+
+	"github.com/labstack/echo/v4"
 )
 
 func FuzzCall(f *testing.F) {
@@ -18,4 +22,21 @@ func FuzzCall(f *testing.F) {
 			t.Errorf("Before: %q", orig)
 		}
 	})
+}
+
+func TestGetHelloWorlod(t *testing.T) {
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/helloworld", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	s := Server{}
+	if err := s.GetHelloWorlod(c); err != nil {
+		t.Fatalf("GetHelloWorlod() failed: %v", err)
+	}
+
+	expected := "HelloWorlod"
+	if rec.Body.String() != expected {
+		t.Errorf("expected %q but got %q", expected, rec.Body.String())
+	}
 }


### PR DESCRIPTION
Add a new API endpoint to return "HelloWorlod".

* **New Handler Function**: Add `GetHelloWorlod` function in `internal/server/server.go` to return "HelloWorlod" as plain text.
* **Register Endpoint**: Register the new handler function in the `NewServer` function in `internal/server/server.go` and in `cmd/main.go`.
* **OpenAPI Specification**: Update `gen/source/basyx-aas.yaml` to include the new endpoint `/helloworld`.
* **Test Case**: Add a test case for the new endpoint in `internal/server/server_test.go`.
* **E2E Test**: Add a new step to test the new endpoint in `e2e/scenario/api.yaml`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/hiroyoshii/go-aas-proxy/pull/301?shareId=b4bb6098-0a71-4e1b-8050-4a7548ed279e).